### PR TITLE
Allow `%Currency{}` structs in `currency_for_code/3`

### DIFF
--- a/lib/cldr/backend.ex
+++ b/lib/cldr/backend.ex
@@ -250,8 +250,8 @@ defmodule Cldr.Currency.Backend do
 
         ## Arguments
 
-        * `currency_code` is a `binary` or `atom` representation of an
-          ISO 4217 currency code.
+        * `currency_or_currency_code` is a `binary` or `atom` representation 
+           of an ISO 4217 currency code, or a `%Cldr.Currency{}` struct.
 
         ## Examples
 
@@ -288,14 +288,14 @@ defmodule Cldr.Currency.Backend do
             }}
 
         """
-        @spec currency_for_code(Cldr.Currency.code, Keyword.t()) ::
-                {:ok, Cldr.Currency.t} | {:error, {module(), String.t()}}
+        @spec currency_for_code(Cldr.Currency.code() | Cldr.Currency.t(), Keyword.t()) ::
+                {:ok, Cldr.Currency.t()} | {:error, {module(), String.t()}}
 
         def currency_for_code(
-              currency_code,
+              currency_or_currency_code,
               options \\ [locale: unquote(backend).default_locale()]
             ) do
-          Cldr.Currency.currency_for_code(currency_code, unquote(backend), options)
+          Cldr.Currency.currency_for_code(currency_or_currency_code, unquote(backend), options)
         end
 
         defp get_currency_metadata(code, nil) do

--- a/lib/cldr/currency.ex
+++ b/lib/cldr/currency.ex
@@ -771,8 +771,8 @@ defmodule Cldr.Currency do
 
   ## Arguments
 
-  * `currency_code` is a `binary` or `atom` representation of an
-    ISO 4217 currency code.
+  * `currency_or_currency_code` is a `binary` or `atom` representation
+      of an ISO 4217 currency code, or a `%Cldr.Currency{}` struct.
 
   * `backend` is any module that includes `use Cldr` and therefore
     is a `Cldr` backend module
@@ -820,16 +820,18 @@ defmodule Cldr.Currency do
 
   """
 
-  @spec currency_for_code(code, Cldr.backend(), Keyword.t()) ::
-          {:ok, t} | {:error, {module(), String.t()}}
+  @spec currency_for_code(code() | t(), Cldr.backend(), Keyword.t()) ::
+          {:ok, t()} | {:error, {module(), String.t()}}
 
-  def currency_for_code(currency_code, backend, options \\ []) do
+  def currency_for_code(currency_or_currency_code, backend, options \\ [])
+  def currency_for_code(%__MODULE__{} = currency, _backend, _options), do: {:ok, currency}
+
+  def currency_for_code(currency_code, backend, options) do
     {locale, backend} = Cldr.locale_and_backend_from(options[:locale], backend)
 
     with {:ok, code} <- known_currency_code(currency_code),
          {:ok, locale} <- Cldr.validate_locale(locale, backend),
          {:ok, currencies} <- currencies_for_locale(locale, backend) do
-
       {:ok, Map.get_lazy(currencies, code, fn -> Map.get(private_currencies(), code) end)}
     end
   end


### PR DESCRIPTION
This PR is part of a series of PRs that aim to improve performance by allowing both `%Cldr.Number.Format.Options{}` structs to be passed as options in place of keyword lists, and to add support for `%Cldr.Currency{}` structs as alternative for currency codes.

https://github.com/elixir-cldr/cldr_currencies/pull/4 (this PR)
https://github.com/elixir-cldr/cldr_numbers/pull/18
https://github.com/kipcole9/money/pull/127

This PR adds support to pass a `%Cldr.Currency` struct directly, and will return it if it's passed to `currency_for_code/3`. Since `currency_for_code/3` is relatively complex, and iterates over currencies (which may be something that can be addressed in a future PR, replacing it with a keyed lookup via a map), this change attempts to offer developers a way to pass the currency struct, already resolved. This in turn made a real-world impact when we ran this in a tight loop. In our use-case, we know the currencies beforehand, and we pre-resolve these currencies. We take the trade-off between slighly higher compile time, and much faster runtime performance.


I ran this benchmark:
https://gist.github.com/jeroenvisser101/32deb85f50fe76f8cd5d48049591e355

```
Operating System: macOS
CPU Information: Intel(R) Xeon(R) W-3245 CPU @ 3.20GHz
Number of Available Cores: 32
Available memory: 160 GB
Elixir 1.12.0
Erlang 24.0

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
parallel: 1
inputs: none specified
Estimated total run time: 42 s

Benchmarking with precompiled everything...
Benchmarking with precompiled options but without precompiled currency...
Benchmarking without precompiled options or currency...

Name                                                                ips        average  deviation         median         99th %
with precompiled everything                                    104.20 K        9.60 μs   ±254.01%        7.99 μs       31.99 μs
with precompiled options but without precompiled currency        2.45 K      408.37 μs    ±45.39%      393.99 μs      627.66 μs
without precompiled options or currency                          2.41 K      414.23 μs    ±10.81%      405.99 μs      588.99 μs

Comparison: 
with precompiled everything                                    104.20 K
with precompiled options but without precompiled currency        2.45 K - 42.55x slower +398.77 μs
without precompiled options or currency                          2.41 K - 43.16x slower +404.64 μs

Memory usage statistics:

Name                                                         Memory usage
with precompiled everything                                       9.51 KB
with precompiled options but without precompiled currency       193.95 KB - 20.40x memory usage +184.45 KB
without precompiled options or currency                         216.27 KB - 22.75x memory usage +206.77 KB

**All measurements for memory usage were the same**
```