### PR TITLE
Fix currency_for_code spec

### DIFF
--- a/lib/cldr/currency.ex
+++ b/lib/cldr/currency.ex
@@ -979,7 +979,7 @@ defmodule Cldr.Currency do
 
   """
 
-  @spec currency_for_code(code() | t(), Cldr.backend(), Keyword.t()) ::
+  @spec currency_for_code(code() | binary() | t(), Cldr.backend(), Keyword.t()) ::
           {:ok, t()} | {:error, {module(), String.t()}}
 
   def currency_for_code(


### PR DESCRIPTION
Cldr.validate_currency also supports binary types, (As a result cldr_currencies does as well)
https://github.com/elixir-cldr/cldr/blob/29ba1d01bab40b8ba9a7ab57adab377c1466332c/lib/cldr.ex#L2023

This PR adds binary to the typespec.

